### PR TITLE
Add Dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,63 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+  schedule:
+    - cron: "11 11 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh label create auto-merge-candidate --color ededed --description "Dependabot dev-dep PR eligible for auto-merge after soak" --force --repo "$GITHUB_REPOSITORY"
+
+      - name: Label dev-dependency PRs
+        if: steps.meta.outputs.dependency-type == 'direct:development' && (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR_URL" --add-label auto-merge-candidate
+
+  soak-and-merge:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      SOAK_DAYS: 3
+    steps:
+      - name: Approve and enable auto-merge on soaked PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cutoff=$(date -u -d "${SOAK_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --author "app/dependabot" \
+            --label auto-merge-candidate \
+            --state open \
+            --json number,createdAt,autoMergeRequest,reviewDecision \
+            --jq ".[] | select(.createdAt < \"$cutoff\") | .number" \
+          | while read -r pr; do
+              decision=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json reviewDecision --jq .reviewDecision)
+              if [ "$decision" != "APPROVED" ]; then
+                echo "Approving PR #$pr"
+                gh pr review "$pr" --approve --repo "$GITHUB_REPOSITORY" --body "Auto-approved after ${SOAK_DAYS}d soak."
+              fi
+              auto=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json autoMergeRequest --jq .autoMergeRequest)
+              if [ "$auto" = "null" ] || [ -z "$auto" ]; then
+                echo "Enabling auto-merge on PR #$pr"
+                gh pr merge "$pr" --auto --squash --repo "$GITHUB_REPOSITORY"
+              fi
+            done


### PR DESCRIPTION
## Changes

- Add `.github/dependabot.yml` to track pip dependencies (`requirements.txt`, `requirements_dev.txt`) on a weekly schedule
- Add `.github/workflows/dependabot-auto-merge.yml` that labels Dependabot dev-dep patch/minor PRs as `auto-merge-candidate`, then on a daily cron approves and enables auto-merge for any candidate older than 3 days
- Closes #24

Note: for auto-merge to actually merge, the repo must have "Allow auto-merge" enabled and branch protection requiring at least one passing check.