### PR TITLE
Replace print statements with logging (closes #18)

### DIFF
--- a/html_to_json/convert_html.py
+++ b/html_to_json/convert_html.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 """Convert html to json."""
 
+import logging
+
 import bs4
+
+logger = logging.getLogger(__name__)
 
 
 def _debug(debug, message, prefix=''):
-    """Print the given message if debugging is true."""
+    """Log the given message if debugging is true."""
     if debug:
-        print('{}{}'.format(prefix, message))
-        # add a newline after every message
-        print('')
+        logger.debug('%s%s', prefix, message)
 
 
 def _record_element_value(element, json_output):


### PR DESCRIPTION
## Changes

- Replace `print()` calls in `html_to_json/convert_html.py:_debug()` with a module-level `logging.getLogger(__name__)` and `logger.debug()`
- Drop the redundant blank-line `print('')` since each log record is already on its own line
- Preserve the existing `debug` flag gating so behavior matches when callers pass `debug=False`