### PR TITLE
Add regression test for issue #21 (lang attribute preservation)

### DIFF
--- a/tests/test_html_to_json.py
+++ b/tests/test_html_to_json.py
@@ -815,3 +815,22 @@ def test_capturing_neither_attributes_nor_values():
 ing<br/>"""
     json_output = html_to_json.convert(html_string, capture_element_values=False, capture_element_attributes=False)
     assert json_output == {'br': [{}, {}, {}], 'p': [{}]}
+
+
+def test_html_lang_attribute_preserved():
+    """Regression test for https://github.com/fhightower/html-to-json/issues/21
+
+    The reporter observed that ``lang="en"`` could be dropped when the document
+    had a ``<head>`` full of un-self-closed ``<meta>`` tags. Make sure the root
+    ``<html>`` element's attributes survive intact.
+    """
+    html_string = """<html lang="en"><head>
+        <meta charset="utf-8">
+        <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+        <meta http-equiv="Pragma" content="no-cache">
+        <meta http-equiv="Expires" content="0">
+        </head>
+        <body></body>
+ </html>"""
+    json_output = html_to_json.convert(html_string)
+    assert json_output['html'][0]['_attributes'] == {'lang': 'en'}


### PR DESCRIPTION
## Changes

- Added `test_html_lang_attribute_preserved` covering the exact HTML from issue #21, asserting that `lang="en"` lands at `output['html'][0]['_attributes']`.
- The reported behavior (lang going missing) is not reproducible against current code across bs4 4.9.3–4.14.3; the test pins the expected behavior so any future regression is caught.

Refs #21