### PR TITLE
Fix IndexError in convert_tables for single-row table with one <th>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is based on the format specified here: [Keep a Changelog](https:/
 - Switch dev workflow from Docker/Docker Compose to `uv`
 - Replace `black`, `isort`, `flake8`, and `pylint` with `ruff`
 - Remove leftover Python 2 compatibility code in `convert_html.py`
+- Fix `IndexError` in `convert_tables` when a table has a single `<tr>` whose first cell is a lone `<th>` (see [#34](https://github.com/fhightower/html-to-json/issues/34))
 
 ## [2.0.0] - 2021-02-27
 

--- a/html_to_json/convert_html_tables.py
+++ b/html_to_json/convert_html_tables.py
@@ -95,7 +95,8 @@ def _process_table(html_table, record_children, debug):
         table_data = _handle_class_a_table(html_table, record_children, debug)
     else:
         if (
-            len(html_table.find_all('tr')[0].find_all('th')) == 1
+            len(html_table.find_all('tr')) > 1
+            and len(html_table.find_all('tr')[0].find_all('th')) == 1
             and len(html_table.find_all('tr')[1].find_all('th')) == 1
         ):
             _debug(debug, table_class_debug_message.format('class B'))

--- a/tests/test_html_tables_misc.py
+++ b/tests/test_html_tables_misc.py
@@ -46,3 +46,10 @@ def test_tables_with_thead():
     html_string = _read_file('./data/Free Proxy Lists.html')
     tables = html_to_json.convert_tables(html_string)
     assert len(tables) == 2
+
+
+def test_single_row_table_with_one_th():
+    """A table with a single <tr> whose first cell is a lone <th> should not raise
+    an IndexError while disambiguating between class A and class B tables (see issue #34)."""
+    tables = html_to_json.convert_tables('<table><tr><th>X</th><td></td></tr></table>')
+    assert tables == []


### PR DESCRIPTION
## Changes

- Guard the `tr[1]` access in `_process_table` so a table with a single `<tr>` whose first cell is a lone `<th>` falls through to the class A branch instead of raising `IndexError`
- Add a regression test for the single-row, single-`<th>` table case
- Add a CHANGELOG entry

Fixes #34