### PR TITLE
Convert boolean flags to keyword-only arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is based on the format specified here: [Keep a Changelog](https:/
 - Switch dev workflow from Docker/Docker Compose to `uv`
 - Replace `black`, `isort`, `flake8`, and `pylint` with `ruff`
 - Remove leftover Python 2 compatibility code in `convert_html.py`
+- **Breaking:** Make the boolean flags keyword-only arguments in `convert` (`debug`, `capture_element_values`, `capture_element_attributes`) and `convert_tables` (`record_children`, `debug`) (see [#9](https://github.com/fhightower/html-to-json/issues/9))
 
 ## [2.0.0] - 2021-02-27
 

--- a/html_to_json/convert_html.py
+++ b/html_to_json/convert_html.py
@@ -32,6 +32,7 @@ def _iterate(
     html_section,
     json_output,
     count,
+    *,
     debug,
     capture_element_values,
     capture_element_attributes,
@@ -65,6 +66,7 @@ def _iterate(
 
 def convert(
     html_string,
+    *,
     debug=False,
     capture_element_values=True,
     capture_element_attributes=True,

--- a/html_to_json/convert_html_tables.py
+++ b/html_to_json/convert_html_tables.py
@@ -6,7 +6,7 @@ import bs4
 from .convert_html import _debug, convert
 
 
-def _handle_class_a_table(table, record_children, debug):
+def _handle_class_a_table(table, *, record_children, debug):
     """Handle tables with the table headers across the top row."""
     table_data = list()
     keys = [item.text for item in table.find_all('tr')[0].find_all('th')]
@@ -31,7 +31,7 @@ def _handle_class_a_table(table, record_children, debug):
     return table_data
 
 
-def _handle_class_b_table(table, record_children, debug):
+def _handle_class_b_table(table, *, record_children, debug):
     """Handle tables with the table headers in the first column (the first cell of each row)."""
     table_data = dict()
 
@@ -55,7 +55,7 @@ def _handle_class_b_table(table, record_children, debug):
     return table_data
 
 
-def _handle_headless_table(table, record_children, debug):
+def _handle_headless_table(table, *, record_children, debug):
     """Handle tables without "th" elements."""
     table_data = list()
 
@@ -80,7 +80,7 @@ def _handle_headless_table(table, record_children, debug):
     return table_data
 
 
-def _process_table(html_table, record_children, debug):
+def _process_table(html_table, *, record_children, debug):
     """Process the given table."""
     table_data = list()
 
@@ -92,24 +92,24 @@ def _process_table(html_table, record_children, debug):
 
     if len(html_table.find_all('tr')[0].find_all('th')) > 1:
         _debug(debug, table_class_debug_message.format('class A'))
-        table_data = _handle_class_a_table(html_table, record_children, debug)
+        table_data = _handle_class_a_table(html_table, record_children=record_children, debug=debug)
     else:
         if (
             len(html_table.find_all('tr')[0].find_all('th')) == 1
             and len(html_table.find_all('tr')[1].find_all('th')) == 1
         ):
             _debug(debug, table_class_debug_message.format('class B'))
-            table_data = _handle_class_b_table(html_table, record_children, debug)
+            table_data = _handle_class_b_table(html_table, record_children=record_children, debug=debug)
         elif len(html_table.find_all('tr')[0].find_all('th')) == 1:
             _debug(debug, table_class_debug_message.format('class A'))
-            table_data = _handle_class_a_table(html_table, record_children, debug)
+            table_data = _handle_class_a_table(html_table, record_children=record_children, debug=debug)
         else:
             _debug(debug, table_class_debug_message.format('headless'))
-            table_data = _handle_headless_table(html_table, record_children, debug)
+            table_data = _handle_headless_table(html_table, record_children=record_children, debug=debug)
     return table_data
 
 
-def convert_tables(html_string, record_children=False, debug=False):
+def convert_tables(html_string, *, record_children=False, debug=False):
     """Convert all of the tables in the html string to json."""
     tables = list()
 
@@ -117,7 +117,7 @@ def convert_tables(html_string, record_children=False, debug=False):
 
     _debug(debug, 'Found {} table(s)'.format(len(soup.find_all('table'))))
     for table in soup.find_all('table'):
-        table_data = _process_table(table, record_children, debug)
+        table_data = _process_table(table, record_children=record_children, debug=debug)
         if table_data:
             tables.append(table_data)
 


### PR DESCRIPTION
## Changes

- Make `convert()`'s `debug`, `capture_element_values`, and `capture_element_attributes` keyword-only arguments
- Make `convert_tables()`'s `record_children` and `debug` keyword-only arguments
- Make the corresponding boolean flags keyword-only in the internal `_iterate`, `_handle_*_table`, and `_process_table` helpers, updating their call sites
- Add a CHANGELOG entry noting the breaking change

Fixes #9