### PR TITLE
Final environment improvements (closes #36)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog is based on the format specified here: [Keep a Changelog](https:/
 - Remove leftover Python 2 compatibility code in `convert_html.py`
 - **Breaking:** Make the boolean flags keyword-only arguments in `convert` (`debug`, `capture_element_values`, `capture_element_attributes`) and `convert_tables` (`record_children`, `debug`) (see [#9](https://github.com/fhightower/html-to-json/issues/9))
 - Fix `IndexError` in `convert_tables` when a table has a single `<tr>` whose first cell is a lone `<th>` (see [#34](https://github.com/fhightower/html-to-json/issues/34))
+- Switch the build backend from `setuptools` to `hatchling`
+- Pin the `beautifulsoup4` runtime dependency to an exact version and the dev dependencies to their major versions
+- Simplify the `ruff` configuration
+- Update the Dependabot `package-ecosystem` from `pip` to `uv` (see [#36](https://github.com/fhightower/html-to-json/issues/36))
 
 ## [2.0.0] - 2021-02-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "html_to_json"
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["beautifulsoup4"]
+dependencies = ["beautifulsoup4==4.14.3"]
 
 [project.urls]
 Homepage = "https://github.com/fhightower/html-to-json"
@@ -36,26 +36,20 @@ Changelog = "https://github.com/fhightower/html-to-json/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [
-    "ipython",
-    "mypy",
-    "pytest",
-    "pytest-cov",
-    "pytest-benchmark",
-    "ruff",
+    "ipython==8.*; python_version < '3.11'",
+    "ipython==9.*; python_version >= '3.11'",
+    "mypy==2.*",
+    "pytest==9.*",
+    "pytest-cov==7.*",
+    "pytest-benchmark==5.*",
+    "ruff==0.*",
 ]
-
-[tool.setuptools.packages.find]
-exclude = ["tests*", "docs*"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM"]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = ["E501", "F841", "W293"]
 
 [tool.ruff.format]
 quote-style = "preserve"

--- a/tests/test_html_to_json.py
+++ b/tests/test_html_to_json.py
@@ -15,7 +15,7 @@ def _read_file(file_name):
 
 def test_content_1():
     html_string = _read_file('./data/test1.html')
-    json_output = html_to_json.convert(html_string)
+    html_to_json.convert(html_string)
 
 
 def test_content_2():

--- a/uv.lock
+++ b/uv.lock
@@ -244,16 +244,17 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "beautifulsoup4" }]
+requires-dist = [{ name = "beautifulsoup4", specifier = "==4.14.3" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ipython" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
+    { name = "ipython", marker = "python_full_version < '3.11'", specifier = "==8.*" },
+    { name = "ipython", marker = "python_full_version >= '3.11'", specifier = "==9.*" },
+    { name = "mypy", specifier = "==2.*" },
+    { name = "pytest", specifier = "==9.*" },
+    { name = "pytest-benchmark", specifier = "==5.*" },
+    { name = "pytest-cov", specifier = "==7.*" },
+    { name = "ruff", specifier = "==0.*" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

- Switch the build backend from `setuptools` to `hatchling`; remove `[tool.setuptools.packages.find]` (hatchling auto-detects the `html_to_json` package)
- Pin the `beautifulsoup4` runtime dependency to an exact version (`==4.14.3`)
- Pin dev dependencies to their major versions (`mypy==2.*`, `pytest==9.*`, `pytest-cov==7.*`, `pytest-benchmark==5.*`, `ruff==0.*`); `ipython` is split by Python version (`==8.*` for `<3.11`, `==9.*` for `>=3.11`) since 9.x dropped Python 3.10
- Simplify the `ruff` config: drop `target-version` (now inferred from `requires-python`) and `[tool.ruff.lint.per-file-ignores]`, keeping `line-length = 120`, `[tool.ruff.lint] select` and `[tool.ruff.format] quote-style = "preserve"`
- Remove a dead `json_output =` assignment in `test_content_1` (`F841`, previously masked by the per-file ignore)
- Change the Dependabot `package-ecosystem` from `pip` to `uv`
- Update `CHANGELOG.md` and re-resolve `uv.lock`