### PR TITLE
Add interactive Pyodide demo and MkDocs site (closes #6)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,16 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  mkdocs-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# MkDocs site build output
+site/
+
 # PyBuilder
 target/
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Convert HTML and/or HTML tables to JSON.
 
+👉 **[Try it in your browser](https://fhightower.github.io/html-to-json/)** — the docs site includes an interactive Pyodide-powered playground for both `convert()` and `convert_tables()`.
+
 If this library is useful to you or if you're using this library for a business - please consider [sponsoring](https://github.com/sponsors/fhightower) me. Even a small sponsorship allows me to prioritize work on this library and ongoing maintainance. Thanks!
 
 ## Installation

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+html-to-json.hightower.space

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,84 @@
+# Interactive Demo
+
+The two demos below run the real `html-to-json` library directly in your browser using [Pyodide](https://pyodide.org/) — no server, no install. Edit the HTML, flip the options, and watch the JSON update.
+
+## 1. `convert()` — any HTML → JSON
+
+<div class="h2j-demo" markdown="0">
+    <div class="h2j-row">
+        <strong>Load example:</strong>
+        <select onchange="loadExample('convertInput', this.value); this.selectedIndex=0;">
+            <option value="">Choose…</option>
+            <option value="head_meta">README: head/meta block</option>
+            <option value="simple">Simple article snippet</option>
+        </select>
+        <span id="convertStatus" class="h2j-status">Booting…</span>
+    </div>
+    <textarea id="convertInput" spellcheck="false"><head>
+    <title>Floyd Hightower's Projects</title>
+    <meta charset="UTF-8">
+    <meta name="description" content="Floyd Hightower's Projects">
+    <meta name="keywords" content="projects,fhightower,Floyd,Hightower">
+</head></textarea>
+    <div class="h2j-options">
+        <label><input type="checkbox" id="captureValues" checked> capture_element_values</label>
+        <label><input type="checkbox" id="captureAttributes" checked> capture_element_attributes</label>
+    </div>
+    <div class="h2j-row">
+        <button class="md-button md-button--primary" id="convertRunBtn" onclick="runConvert()" disabled>Convert</button>
+    </div>
+    <div class="h2j-output-actions">
+        <button class="md-button" onclick="copyOutput('convertOutput', this)">Copy JSON</button>
+        <button class="md-button" onclick="downloadOutput('convertOutput', 'converted.json')">Download JSON</button>
+    </div>
+    <pre id="convertOutput"></pre>
+</div>
+
+## 2. `convert_tables()` — HTML tables → JSON
+
+<div class="h2j-demo" markdown="0">
+    <div class="h2j-row">
+        <strong>Load example:</strong>
+        <select onchange="loadExample('tablesInput', this.value); this.selectedIndex=0;">
+            <option value="">Choose…</option>
+            <option value="table_headers_row">README: malware table (headers in first row)</option>
+            <option value="table_no_headers">Table without headers</option>
+        </select>
+        <span id="tablesStatus" class="h2j-status">Booting…</span>
+    </div>
+    <textarea id="tablesInput" spellcheck="false"><table>
+    <tr>
+        <th>#</th>
+        <th>Malware</th>
+        <th>MD5</th>
+        <th>Date Added</th>
+    </tr>
+    <tr>
+        <td>25548</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/034a37b2a2307f876adc9538986d7b86">034a37b2a2307f876adc9538986d7b86</a></td>
+        <td>July 9, 2018, 6:25 a.m.</td>
+    </tr>
+    <tr>
+        <td>25547</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/706eeefbac3de4d58b27d964173999c3">706eeefbac3de4d58b27d964173999c3</a></td>
+        <td>July 7, 2018, 6:25 a.m.</td>
+    </tr>
+</table></textarea>
+    <div class="h2j-options">
+        <label><input type="checkbox" id="recordHtml"> record_html</label>
+        <label><input type="checkbox" id="recordChildren"> record_children</label>
+    </div>
+    <div class="h2j-row">
+        <button class="md-button md-button--primary" id="tablesRunBtn" onclick="runTables()" disabled>Convert tables</button>
+    </div>
+    <div class="h2j-output-actions">
+        <button class="md-button" onclick="copyOutput('tablesOutput', this)">Copy JSON</button>
+        <button class="md-button" onclick="downloadOutput('tablesOutput', 'tables.json')">Download JSON</button>
+    </div>
+    <pre id="tablesOutput"></pre>
+</div>
+
+!!! info "About this demo"
+    The widgets above run Python in the browser via [Pyodide](https://pyodide.org/) and [WebAssembly](https://webassembly.org/). The first load installs the `html-to-json` wheel from PyPI in-browser and takes a few seconds; subsequent conversions are instant.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,41 @@
+## Development
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency and environment management. Python 3.10+ is required.
+
+### Setup
+
+```shell
+git clone git@github.com:fhightower/html-to-json.git && cd html-to-json
+uv sync
+```
+
+### Tests and linting
+
+```shell
+uv run pytest
+./scripts/lint.sh
+```
+
+### Building the docs
+
+The docs are built with [MkDocs](https://www.mkdocs.org/) and the [Material](https://squidfunk.github.io/mkdocs-material/) theme.
+
+```shell
+pip install mkdocs-material
+mkdocs serve  # live-reload preview at http://127.0.0.1:8000
+mkdocs build  # static site in ./site
+```
+
+The interactive demo on the home page runs the library directly in the browser via [Pyodide](https://pyodide.org/). The Pyodide bootstrap lives in `docs/overrides/main.html`; the markup for the widgets is in `docs/index.md`.
+
+When the home page loads, the override script:
+
+1. Loads Pyodide from the CDN.
+2. Calls `micropip.install("html-to-json")` to install the latest published wheel from PyPI.
+3. Wires the `Convert` / `Convert tables` buttons to `html_to_json.convert` and `html_to_json.convert_tables`.
+
+To test the demo against an unreleased version of the library, replace the `micropip.install("html-to-json")` call in `docs/overrides/main.html` with a `micropip.install` of a local wheel URL, or paste the source of `convert_html.py` / `convert_html_tables.py` directly into the bootstrap.
+
+### Releasing
+
+Releases are published to PyPI via the `python-publish.yml` GitHub Actions workflow. After a release, the in-browser demo will pick up the new version automatically the next time the page is loaded (Pyodide always installs the latest from PyPI).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,147 @@
+# HTML to JSON
+
+[![PyPI](https://img.shields.io/pypi/v/html-to-json.svg)](https://pypi.python.org/pypi/html-to-json)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/html-to-json)
+[![codecov](https://codecov.io/gh/fhightower/html-to-json/branch/main/graph/badge.svg?token=V0WOIXRGMM)](https://codecov.io/gh/fhightower/html-to-json)
+
+Welcome to the documentation for the `html-to-json` library — a small Python library for converting HTML (and HTML tables) to JSON.
+
+📢 *If this library is useful to you, please consider [sponsoring](https://github.com/sponsors/fhightower) the project.*
+
+## Quick-Start
+
+Install html-to-json:
+
+```shell
+pip install html-to-json
+```
+
+Use it:
+
+```python
+import html_to_json
+
+html_string = """<head>
+    <title>Test site</title>
+    <meta charset="UTF-8"></head>"""
+
+output_json = html_to_json.convert(html_string)
+print(output_json)
+```
+
+## Try it in your browser (INTERACTIVE!)
+
+The two demos below run the real `html-to-json` library directly in your browser using [Pyodide](https://pyodide.org/) — no server, no install. Edit the HTML, flip the options, and watch the JSON update.
+
+### 1. `convert()` — any HTML → JSON
+
+<div class="h2j-demo" markdown="0">
+    <div class="h2j-row">
+        <strong>Load example:</strong>
+        <select onchange="loadExample('convertInput', this.value); this.selectedIndex=0;">
+            <option value="">Choose…</option>
+            <option value="head_meta">README: head/meta block</option>
+            <option value="simple">Simple article snippet</option>
+        </select>
+        <span id="convertStatus" class="h2j-status">Booting…</span>
+    </div>
+    <textarea id="convertInput" spellcheck="false"><head>
+    <title>Floyd Hightower's Projects</title>
+    <meta charset="UTF-8">
+    <meta name="description" content="Floyd Hightower's Projects">
+    <meta name="keywords" content="projects,fhightower,Floyd,Hightower">
+</head></textarea>
+    <div class="h2j-options">
+        <label><input type="checkbox" id="captureValues" checked> capture_element_values</label>
+        <label><input type="checkbox" id="captureAttributes" checked> capture_element_attributes</label>
+    </div>
+    <div class="h2j-row">
+        <button class="md-button md-button--primary" id="convertRunBtn" onclick="runConvert()" disabled>Convert</button>
+    </div>
+    <div class="h2j-output-actions">
+        <button class="md-button" onclick="copyOutput('convertOutput', this)">Copy JSON</button>
+        <button class="md-button" onclick="downloadOutput('convertOutput', 'converted.json')">Download JSON</button>
+    </div>
+    <pre id="convertOutput"></pre>
+</div>
+
+### 2. `convert_tables()` — HTML tables → JSON
+
+<div class="h2j-demo" markdown="0">
+    <div class="h2j-row">
+        <strong>Load example:</strong>
+        <select onchange="loadExample('tablesInput', this.value); this.selectedIndex=0;">
+            <option value="">Choose…</option>
+            <option value="table_headers_row">README: malware table (headers in first row)</option>
+            <option value="table_no_headers">Table without headers</option>
+        </select>
+        <span id="tablesStatus" class="h2j-status">Booting…</span>
+    </div>
+    <textarea id="tablesInput" spellcheck="false"><table>
+    <tr>
+        <th>#</th>
+        <th>Malware</th>
+        <th>MD5</th>
+        <th>Date Added</th>
+    </tr>
+    <tr>
+        <td>25548</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/034a37b2a2307f876adc9538986d7b86">034a37b2a2307f876adc9538986d7b86</a></td>
+        <td>July 9, 2018, 6:25 a.m.</td>
+    </tr>
+    <tr>
+        <td>25547</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/706eeefbac3de4d58b27d964173999c3">706eeefbac3de4d58b27d964173999c3</a></td>
+        <td>July 7, 2018, 6:25 a.m.</td>
+    </tr>
+</table></textarea>
+    <div class="h2j-options">
+        <label><input type="checkbox" id="recordHtml"> record_html</label>
+        <label><input type="checkbox" id="recordChildren"> record_children</label>
+    </div>
+    <div class="h2j-row">
+        <button class="md-button md-button--primary" id="tablesRunBtn" onclick="runTables()" disabled>Convert tables</button>
+    </div>
+    <div class="h2j-output-actions">
+        <button class="md-button" onclick="copyOutput('tablesOutput', this)">Copy JSON</button>
+        <button class="md-button" onclick="downloadOutput('tablesOutput', 'tables.json')">Download JSON</button>
+    </div>
+    <pre id="tablesOutput"></pre>
+</div>
+
+!!! info "About this demo"
+    The widgets above run Python in the browser via [Pyodide](https://pyodide.org/) and [WebAssembly](https://webassembly.org/). The first load installs the `html-to-json` wheel from PyPI in-browser and takes a few seconds; subsequent conversions are instant.
+
+## Capabilities
+
+??? info "What this library converts"
+
+    - Arbitrary HTML to a JSON-friendly Python dictionary (`html_to_json.convert`)
+    - HTML tables to a list of row dictionaries (`html_to_json.convert_tables`), including:
+        - Tables with headers in the first row
+        - Tables with headers in the first column
+        - Tables without headers
+
+??? info "Configuration options"
+
+    `convert()`:
+
+    - `capture_element_values` (default `True`) — capture the text inside each element under the `_value` key.
+    - `capture_element_attributes` (default `True`) — capture each element's attributes under the `_attributes` key.
+
+    `convert_tables()`:
+
+    - `record_html` (default `False`) — capture each cell's inner HTML as a string. Useful for preserving links and other inline markup.
+    - `record_children` (default `False`) — capture each cell's children as JSON (using the same shape produced by `convert`). If both flags are set, `record_html` wins.
+
+## Feedback
+
+If you have ideas to improve this package, please [open an issue][issues_link]!
+
+## Credits
+
+This package was created with [Cookiecutter](https://github.com/audreyr/cookiecutter) and fhightower's [Python project template](https://github.com/fhightower-templates/python-project-template).
+
+[issues_link]: https://github.com/fhightower/html-to-json/issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,88 +31,9 @@ print(output_json)
 
 ## Try it in your browser (INTERACTIVE!)
 
-The two demos below run the real `html-to-json` library directly in your browser using [Pyodide](https://pyodide.org/) — no server, no install. Edit the HTML, flip the options, and watch the JSON update.
+No install required — run the real `html-to-json` library right in your browser via [Pyodide](https://pyodide.org/). Edit some HTML, flip the options, and watch the JSON update live.
 
-### 1. `convert()` — any HTML → JSON
-
-<div class="h2j-demo" markdown="0">
-    <div class="h2j-row">
-        <strong>Load example:</strong>
-        <select onchange="loadExample('convertInput', this.value); this.selectedIndex=0;">
-            <option value="">Choose…</option>
-            <option value="head_meta">README: head/meta block</option>
-            <option value="simple">Simple article snippet</option>
-        </select>
-        <span id="convertStatus" class="h2j-status">Booting…</span>
-    </div>
-    <textarea id="convertInput" spellcheck="false"><head>
-    <title>Floyd Hightower's Projects</title>
-    <meta charset="UTF-8">
-    <meta name="description" content="Floyd Hightower's Projects">
-    <meta name="keywords" content="projects,fhightower,Floyd,Hightower">
-</head></textarea>
-    <div class="h2j-options">
-        <label><input type="checkbox" id="captureValues" checked> capture_element_values</label>
-        <label><input type="checkbox" id="captureAttributes" checked> capture_element_attributes</label>
-    </div>
-    <div class="h2j-row">
-        <button class="md-button md-button--primary" id="convertRunBtn" onclick="runConvert()" disabled>Convert</button>
-    </div>
-    <div class="h2j-output-actions">
-        <button class="md-button" onclick="copyOutput('convertOutput', this)">Copy JSON</button>
-        <button class="md-button" onclick="downloadOutput('convertOutput', 'converted.json')">Download JSON</button>
-    </div>
-    <pre id="convertOutput"></pre>
-</div>
-
-### 2. `convert_tables()` — HTML tables → JSON
-
-<div class="h2j-demo" markdown="0">
-    <div class="h2j-row">
-        <strong>Load example:</strong>
-        <select onchange="loadExample('tablesInput', this.value); this.selectedIndex=0;">
-            <option value="">Choose…</option>
-            <option value="table_headers_row">README: malware table (headers in first row)</option>
-            <option value="table_no_headers">Table without headers</option>
-        </select>
-        <span id="tablesStatus" class="h2j-status">Booting…</span>
-    </div>
-    <textarea id="tablesInput" spellcheck="false"><table>
-    <tr>
-        <th>#</th>
-        <th>Malware</th>
-        <th>MD5</th>
-        <th>Date Added</th>
-    </tr>
-    <tr>
-        <td>25548</td>
-        <td><a href="/stats/DarkComet/">DarkComet</a></td>
-        <td><a href="/config/034a37b2a2307f876adc9538986d7b86">034a37b2a2307f876adc9538986d7b86</a></td>
-        <td>July 9, 2018, 6:25 a.m.</td>
-    </tr>
-    <tr>
-        <td>25547</td>
-        <td><a href="/stats/DarkComet/">DarkComet</a></td>
-        <td><a href="/config/706eeefbac3de4d58b27d964173999c3">706eeefbac3de4d58b27d964173999c3</a></td>
-        <td>July 7, 2018, 6:25 a.m.</td>
-    </tr>
-</table></textarea>
-    <div class="h2j-options">
-        <label><input type="checkbox" id="recordHtml"> record_html</label>
-        <label><input type="checkbox" id="recordChildren"> record_children</label>
-    </div>
-    <div class="h2j-row">
-        <button class="md-button md-button--primary" id="tablesRunBtn" onclick="runTables()" disabled>Convert tables</button>
-    </div>
-    <div class="h2j-output-actions">
-        <button class="md-button" onclick="copyOutput('tablesOutput', this)">Copy JSON</button>
-        <button class="md-button" onclick="downloadOutput('tablesOutput', 'tables.json')">Download JSON</button>
-    </div>
-    <pre id="tablesOutput"></pre>
-</div>
-
-!!! info "About this demo"
-    The widgets above run Python in the browser via [Pyodide](https://pyodide.org/) and [WebAssembly](https://webassembly.org/). The first load installs the `html-to-json` wheel from PyPI in-browser and takes a few seconds; subsequent conversions are instant.
+[Open the interactive demo :material-arrow-right:](demo.md){ .md-button .md-button--primary }
 
 ## Capabilities
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,230 @@
+{% extends "base.html" %}
+
+{% block libs %}
+    {{ super() }}
+
+    <style>
+        .h2j-demo {
+            margin: 1rem 0 2rem;
+        }
+        .h2j-demo textarea {
+            width: 100%;
+            min-height: 8rem;
+            font-family: var(--md-code-font-family, monospace);
+            font-size: 0.85rem;
+        }
+        .h2j-demo pre {
+            white-space: pre-wrap;
+            word-break: break-word;
+            max-height: 28rem;
+            overflow: auto;
+        }
+        .h2j-demo .h2j-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            align-items: center;
+            margin: 0.5rem 0;
+        }
+        .h2j-demo .h2j-options {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin: 0.25rem 0 0.75rem;
+            font-size: 0.85rem;
+        }
+        .h2j-demo .h2j-options label {
+            cursor: pointer;
+            user-select: none;
+        }
+        .h2j-demo .h2j-status {
+            font-size: 0.85rem;
+            color: var(--md-default-fg-color--light);
+            margin-left: 0.25rem;
+        }
+        .h2j-demo .h2j-output-wrap {
+            position: relative;
+        }
+        .h2j-demo .h2j-output-actions {
+            display: flex;
+            gap: 0.5rem;
+            margin: 0.5rem 0;
+        }
+        .h2j-demo select {
+            font: inherit;
+            padding: 0.2rem 0.4rem;
+        }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"></script>
+
+    <script>
+        "use strict";
+        let pyodide = undefined;
+        let pyodideReady = false;
+
+        const EXAMPLES = {
+            "head_meta": `<head>
+    <title>Floyd Hightower's Projects</title>
+    <meta charset="UTF-8">
+    <meta name="description" content="Floyd Hightower's Projects">
+    <meta name="keywords" content="projects,fhightower,Floyd,Hightower">
+</head>`,
+            "simple": `<div class="post">
+    <h1>Hello, world!</h1>
+    <p>This is a <a href="https://example.com">link</a>.</p>
+</div>`,
+            "table_headers_row": `<table>
+    <tr>
+        <th>#</th>
+        <th>Malware</th>
+        <th>MD5</th>
+        <th>Date Added</th>
+    </tr>
+    <tr>
+        <td>25548</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/034a37b2a2307f876adc9538986d7b86">034a37b2a2307f876adc9538986d7b86</a></td>
+        <td>July 9, 2018, 6:25 a.m.</td>
+    </tr>
+    <tr>
+        <td>25547</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/706eeefbac3de4d58b27d964173999c3">706eeefbac3de4d58b27d964173999c3</a></td>
+        <td>July 7, 2018, 6:25 a.m.</td>
+    </tr>
+</table>`,
+            "table_no_headers": `<table>
+    <tr><td>apple</td><td>red</td><td>1</td></tr>
+    <tr><td>banana</td><td>yellow</td><td>2</td></tr>
+    <tr><td>grape</td><td>purple</td><td>3</td></tr>
+</table>`
+        };
+
+        function setStatus(id, text) {
+            const el = document.getElementById(id);
+            if (el) el.textContent = text;
+        }
+
+        function setRunButtonsEnabled(enabled) {
+            for (const id of ['convertRunBtn', 'tablesRunBtn']) {
+                const b = document.getElementById(id);
+                if (b) {
+                    b.disabled = !enabled;
+                    if (enabled && b.dataset.label) b.innerHTML = b.dataset.label;
+                }
+            }
+        }
+
+        async function bootPyodide() {
+            setStatus('convertStatus', 'Loading Pyodide…');
+            setStatus('tablesStatus', 'Loading Pyodide…');
+            pyodide = await loadPyodide();
+            setStatus('convertStatus', 'Installing html-to-json…');
+            setStatus('tablesStatus', 'Installing html-to-json…');
+            await pyodide.loadPackage(["micropip", "beautifulsoup4"]);
+            await pyodide.runPythonAsync(`
+import micropip
+await micropip.install("html-to-json")
+import json
+import html_to_json
+            `);
+            pyodideReady = true;
+            setStatus('convertStatus', 'Ready 🎉');
+            setStatus('tablesStatus', 'Ready 🎉');
+            setRunButtonsEnabled(true);
+        }
+
+        function jsBoolToPy(b) {
+            return b ? 'True' : 'False';
+        }
+
+        async function runConvert() {
+            if (!pyodideReady) return;
+            const input = document.getElementById('convertInput').value;
+            const capVals = document.getElementById('captureValues').checked;
+            const capAttrs = document.getElementById('captureAttributes').checked;
+            try {
+                pyodide.globals.set('h2j_input', input);
+                const out = await pyodide.runPythonAsync(`
+result = html_to_json.convert(
+    h2j_input,
+    capture_element_values=${jsBoolToPy(capVals)},
+    capture_element_attributes=${jsBoolToPy(capAttrs)},
+)
+json.dumps(result, indent=4, sort_keys=False, ensure_ascii=False)
+                `);
+                document.getElementById('convertOutput').textContent = out;
+            } catch (err) {
+                document.getElementById('convertOutput').textContent = 'Error: ' + err.message;
+            }
+        }
+
+        async function runTables() {
+            if (!pyodideReady) return;
+            const input = document.getElementById('tablesInput').value;
+            const recordHtml = document.getElementById('recordHtml').checked;
+            const recordChildren = document.getElementById('recordChildren').checked;
+            try {
+                pyodide.globals.set('h2j_input', input);
+                const out = await pyodide.runPythonAsync(`
+result = html_to_json.convert_tables(
+    h2j_input,
+    record_html=${jsBoolToPy(recordHtml)},
+    record_children=${jsBoolToPy(recordChildren)},
+)
+json.dumps(result, indent=4, sort_keys=False, ensure_ascii=False)
+                `);
+                document.getElementById('tablesOutput').textContent = out;
+            } catch (err) {
+                document.getElementById('tablesOutput').textContent = 'Error: ' + err.message;
+            }
+        }
+
+        function loadExample(targetId, exampleKey) {
+            const el = document.getElementById(targetId);
+            if (el && EXAMPLES[exampleKey]) {
+                el.value = EXAMPLES[exampleKey];
+            }
+        }
+
+        async function copyOutput(outputId, btn) {
+            const text = document.getElementById(outputId).textContent || '';
+            if (!text) return;
+            try {
+                await navigator.clipboard.writeText(text);
+                const orig = btn.innerHTML;
+                btn.innerHTML = 'Copied!';
+                setTimeout(() => { btn.innerHTML = orig; }, 1200);
+            } catch (e) {
+                btn.innerHTML = 'Copy failed';
+            }
+        }
+
+        function downloadOutput(outputId, filename) {
+            const text = document.getElementById(outputId).textContent || '';
+            if (!text) return;
+            const blob = new Blob([text], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            for (const id of ['convertRunBtn', 'tablesRunBtn']) {
+                const b = document.getElementById(id);
+                if (b) b.dataset.label = b.innerHTML;
+            }
+            setRunButtonsEnabled(false);
+            bootPyodide().catch(err => {
+                setStatus('convertStatus', 'Failed to load: ' + err.message);
+                setStatus('tablesStatus', 'Failed to load: ' + err.message);
+            });
+        });
+    </script>
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -122,7 +122,7 @@
             pyodide = await loadPyodide();
             setStatus('convertStatus', 'Installing html-to-json…');
             setStatus('tablesStatus', 'Installing html-to-json…');
-            await pyodide.loadPackage(["micropip", "beautifulsoup4"]);
+            await pyodide.loadPackage(["micropip"]);
             await pyodide.runPythonAsync(`
 import micropip
 await micropip.install("html-to-json")
@@ -215,7 +215,20 @@ json.dumps(result, indent=4, sort_keys=False, ensure_ascii=False)
             URL.revokeObjectURL(url);
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
+        let bootStarted = false;
+
+        function initDemo() {
+            if (!document.querySelector('.h2j-demo')) return;
+            // If Pyodide is already up (e.g. after instant navigation back to
+            // this page), just re-sync the button state instead of re-booting.
+            if (pyodideReady) {
+                setStatus('convertStatus', 'Ready 🎉');
+                setStatus('tablesStatus', 'Ready 🎉');
+                setRunButtonsEnabled(true);
+                return;
+            }
+            if (bootStarted) return;
+            bootStarted = true;
             for (const id of ['convertRunBtn', 'tablesRunBtn']) {
                 const b = document.getElementById(id);
                 if (b) b.dataset.label = b.innerHTML;
@@ -225,6 +238,25 @@ json.dumps(result, indent=4, sort_keys=False, ensure_ascii=False)
                 setStatus('convertStatus', 'Failed to load: ' + err.message);
                 setStatus('tablesStatus', 'Failed to load: ' + err.message);
             });
-        });
+        }
+
+        // Material's `navigation.instant` swaps page content without firing
+        // DOMContentLoaded, so subscribe to its `document$` observable, which
+        // replays for the current page and emits on every instant navigation.
+        // This script lives in the <head>, so `document$` (defined by Material's
+        // bundle at the end of <body>) isn't available yet — wait for the DOM to
+        // be ready before wiring it up, then fall back if it's still missing.
+        function setupDemoLoader() {
+            if (typeof document$ !== 'undefined' && document$.subscribe) {
+                document$.subscribe(initDemo);
+            } else {
+                initDemo();
+            }
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', setupDemoLoader);
+        } else {
+            setupDemoLoader();
+        }
     </script>
 {% endblock %}

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,149 @@
+## Installation
+
+The recommended means of installation is using [pip](https://pypi.python.org/pypi/pip/):
+
+```shell
+pip install html-to-json
+```
+
+Alternatively, you can work with a local checkout:
+
+```shell
+git clone git@github.com:fhightower/html-to-json.git && cd html-to-json
+uv sync
+```
+
+## Usage
+
+### HTML to JSON
+
+```python
+import html_to_json
+
+html_string = """<head>
+    <title>Test site</title>
+    <meta charset="UTF-8"></head>"""
+output_json = html_to_json.convert(html_string)
+print(output_json)
+```
+
+`html_to_json.convert` accepts the following keyword arguments:
+
+- `capture_element_values` (default `True`) — capture the text inside each element under the `_value` key.
+- `capture_element_attributes` (default `True`) — capture each element's attributes under the `_attributes` key.
+
+#### Example
+
+Input:
+
+```html
+<head>
+    <title>Floyd Hightower's Projects</title>
+    <meta charset="UTF-8">
+    <meta name="description" content="Floyd Hightower&#39;s Projects">
+    <meta name="keywords" content="projects,fhightower,Floyd,Hightower">
+</head>
+```
+
+Output:
+
+```json
+{
+    "head": [
+    {
+        "title": [
+        {
+            "_value": "Floyd Hightower's Projects"
+        }],
+        "meta": [
+        {
+            "_attributes":
+            {
+                "charset": "UTF-8"
+            }
+        },
+        {
+            "_attributes":
+            {
+                "name": "description",
+                "content": "Floyd Hightower's Projects"
+            }
+        },
+        {
+            "_attributes":
+            {
+                "name": "keywords",
+                "content": "projects,fhightower,Floyd,Hightower"
+            }
+        }]
+    }]
+}
+```
+
+### HTML tables to JSON
+
+This library can intelligently convert HTML tables to JSON. It handles three shapes:
+
+- A. Tables with [table headers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th) in the first row
+- B. Tables with table headers in the first column
+- C. Tables without table headers
+
+#### Example
+
+```python
+import html_to_json
+
+html_string = """<table>
+    <tr>
+        <th>#</th>
+        <th>Malware</th>
+        <th>MD5</th>
+        <th>Date Added</th>
+    </tr>
+    <tr>
+        <td>25548</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/034a37b2a2307f876adc9538986d7b86">034a37b2a2307f876adc9538986d7b86</a></td>
+        <td>July 9, 2018, 6:25 a.m.</td>
+    </tr>
+    <tr>
+        <td>25547</td>
+        <td><a href="/stats/DarkComet/">DarkComet</a></td>
+        <td><a href="/config/706eeefbac3de4d58b27d964173999c3">706eeefbac3de4d58b27d964173999c3</a></td>
+        <td>July 7, 2018, 6:25 a.m.</td>
+    </tr></table>"""
+tables = html_to_json.convert_tables(html_string)
+print(tables)
+```
+
+produces:
+
+```json
+[
+    [
+        {
+            "#": "25548",
+            "Malware": "DarkComet",
+            "MD5": "034a37b2a2307f876adc9538986d7b86",
+            "Date Added": "July 9, 2018, 6:25 a.m."
+        },
+        {
+            "#": "25547",
+            "Malware": "DarkComet",
+            "MD5": "706eeefbac3de4d58b27d964173999c3",
+            "Date Added": "July 7, 2018, 6:25 a.m."
+        }
+    ]
+]
+```
+
+#### Preserving nested tags in table cells
+
+By default, `convert_tables()` only captures the *text* of each cell, so nested tags (such as `<a>` elements) and their attributes are dropped. To keep them, pass one of:
+
+- `record_html=True` — capture each cell's inner HTML as a string.
+- `record_children=True` — capture each cell's children as JSON, using the same structure produced by `convert()`.
+
+If both are given, `record_html` takes precedence.
+
+For more examples, see [`tests/`](https://github.com/fhightower/html-to-json/tree/main/tests) or play with the [interactive demo](index.md#try-it-in-your-browser-interactive).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: HTML to JSON Docs
+site_url: ""
+repo_url: https://github.com/fhightower/html-to-json
+repo_name: html-to-json
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to dark mode
+      primary: deep orange
+      accent: deep orange
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/lightbulb
+        name: Switch to light mode
+      primary: deep orange
+      accent: deep orange
+  font: false
+  icon:
+    logo: material/code-json
+  features:
+    - navigation.instant
+    - navigation.top
+    - header.autohide
+    - toc.integrate
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - attr_list
+  - admonition
+  - pymdownx.details
+  - meta
+  - toc:
+      permalink: true
+nav:
+    - Home: index.md
+    - Quick Start: quick-start.md
+    - Developer Docs: development.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,10 +34,14 @@ markdown_extensions:
   - attr_list
   - admonition
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - meta
   - toc:
       permalink: true
 nav:
     - Home: index.md
+    - Interactive Demo: demo.md
     - Quick Start: quick-start.md
     - Developer Docs: development.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: HTML to JSON Docs
-site_url: ""
+site_url: https://html-to-json.hightower.space/
 repo_url: https://github.com/fhightower/html-to-json
 repo_name: html-to-json
 theme:


### PR DESCRIPTION
## Changes

- Add MkDocs Material docs site (`mkdocs.yml`, `docs/index.md`, `docs/quick-start.md`, `docs/development.md`) mirroring the structure of fhightower/ioc-finder
- Add interactive in-browser demo on the docs home page powered by Pyodide, with widgets for `convert()` and `convert_tables()` including option toggles, preloaded examples, and copy/download JSON buttons (`docs/overrides/main.html`)
- Add `Docs` GitHub Actions workflow that runs `mkdocs gh-deploy` on push to `main` (`.github/workflows/docs.yml`)
- Link to the live playground from the project README
- Ignore the `site/` build output in `.gitignore`