### PR TITLE
Add json_to_html() to convert JSON back to HTML (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog is based on the format specified here: [Keep a Changelog](https:/
 
 ## [Unreleased]
 
+### Added
+
+- Add `json_to_html()` to convert the JSON output of `convert()` back into an HTML string, supporting the convert-edit-convert-back workflow (see [#23](https://github.com/fhightower/html-to-json/issues/23))
+
 ## [3.0.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ Example output:
 }
 ```
 
+### JSON back to HTML
+
+If you've converted HTML to JSON, made some edits to the resulting data, and want to turn it back into HTML, use `json_to_html`:
+
+```python
+import html_to_json
+
+data = html_to_json.convert('<div><p>old text</p></div>')
+data['div'][0]['p'][0]['_value'] = 'new text'
+print(html_to_json.json_to_html(data))
+# <div><p>new text</p></div>
+```
+
+Text and attribute values are HTML-escaped, list-valued attributes (such as `class`) are space-joined, and HTML5 void elements (`<br>`, `<meta>`, `<img>`, etc.) are rendered without a closing tag.
+
+Round-tripping is not lossless: the JSON representation groups sibling elements by tag name, so the relative order between *different* tags (and between tags and free-floating text captured in `_values`) is not preserved. Text captured in `_value`/`_values` is emitted before any child tags of the same node.
+
 ### HTML Tables to JSON
 
 In addition to converting HTML to JSON, this library can also intelligently convert HTML tables to JSON.

--- a/html_to_json/__init__.py
+++ b/html_to_json/__init__.py
@@ -1,5 +1,6 @@
 from .convert_html import convert  # noqa: F401
 from .convert_html_tables import convert_tables  # noqa: F401
+from .convert_json import json_to_html  # noqa: F401
 
 __author__ = """Floyd Hightower"""
 __version__ = '3.0.0'

--- a/html_to_json/convert_json.py
+++ b/html_to_json/convert_json.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""Convert the JSON produced by :func:`html_to_json.convert` back to HTML."""
+
+from html import escape
+from typing import Any
+
+JSONDict = dict[str, Any]
+
+# HTML5 void elements - rendered without a closing tag.
+# https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+_VOID_ELEMENTS = frozenset(
+    {
+        'area',
+        'base',
+        'br',
+        'col',
+        'embed',
+        'hr',
+        'img',
+        'input',
+        'link',
+        'meta',
+        'param',
+        'source',
+        'track',
+        'wbr',
+    }
+)
+
+
+def _render_attribute_value(value: Any) -> str:
+    if isinstance(value, list):
+        return ' '.join(str(item) for item in value)
+    return str(value)
+
+
+def _render_attributes(attributes: dict[str, Any]) -> str:
+    parts = []
+    for name, value in attributes.items():
+        if value is True or value == '':
+            parts.append(name)
+        elif value is False or value is None:
+            continue
+        else:
+            parts.append(f'{name}="{escape(_render_attribute_value(value), quote=True)}"')
+    return ''.join(' ' + part for part in parts)
+
+
+def _render_node(tag: str, node: JSONDict) -> str:
+    attributes = node.get('_attributes', {})
+    opening = f'<{tag}{_render_attributes(attributes)}>'
+
+    if tag in _VOID_ELEMENTS:
+        return opening
+
+    inner = _render_children(node)
+    return f'{opening}{inner}</{tag}>'
+
+
+def _render_children(node: JSONDict) -> str:
+    pieces: list[str] = []
+
+    if '_value' in node:
+        pieces.append(escape(str(node['_value'])))
+    if '_values' in node:
+        pieces.extend(escape(str(value)) for value in node['_values'])
+
+    for key, children in node.items():
+        if key in ('_value', '_values', '_attributes'):
+            continue
+        if not isinstance(children, list):
+            continue
+        for child in children:
+            pieces.append(_render_node(key, child))
+
+    return ''.join(pieces)
+
+
+def json_to_html(json_input: JSONDict) -> str:
+    """Convert a JSON dictionary produced by :func:`convert` back to an HTML string.
+
+    The inverse is not perfect: the JSON representation groups sibling elements
+    by tag name, so the relative order between *different* tags (and between
+    tags and free-floating text nodes captured in ``_values``) is lost. Text
+    captured in ``_value``/``_values`` is emitted before any child tags.
+    """
+    return _render_children(json_input)

--- a/html_to_json/convert_json.py
+++ b/html_to_json/convert_json.py
@@ -4,7 +4,7 @@
 from html import escape
 from typing import Any
 
-JSONDict = dict[str, Any]
+from .convert_html import JSONDict
 
 # HTML5 void elements - rendered without a closing tag.
 # https://html.spec.whatwg.org/multipage/syntax.html#void-elements
@@ -60,10 +60,12 @@ def _render_node(tag: str, node: JSONDict) -> str:
 def _render_children(node: JSONDict) -> str:
     pieces: list[str] = []
 
+    # Text content only needs ``&``/``<``/``>`` escaped; quotes are significant
+    # only inside attribute values, so keep them literal for round-trip fidelity.
     if '_value' in node:
-        pieces.append(escape(str(node['_value'])))
+        pieces.append(escape(str(node['_value']), quote=False))
     if '_values' in node:
-        pieces.extend(escape(str(value)) for value in node['_values'])
+        pieces.extend(escape(str(value), quote=False) for value in node['_values'])
 
     for key, children in node.items():
         if key in ('_value', '_values', '_attributes'):

--- a/tests/test_json_to_html.py
+++ b/tests/test_json_to_html.py
@@ -113,3 +113,9 @@ def test_boolean_attribute_true_renders_bare():
 def test_boolean_attribute_false_omitted():
     json_input = {'input': [{'_attributes': {'type': 'checkbox', 'checked': False}}]}
     assert html_to_json.json_to_html(json_input) == '<input type="checkbox">'
+
+
+def test_non_list_tag_value_is_skipped():
+    """Defensively ignore malformed nodes whose tag value isn't a list."""
+    json_input = {'div': [{'_value': 'keep', 'p': 'not a list'}]}
+    assert html_to_json.json_to_html(json_input) == '<div>keep</div>'

--- a/tests/test_json_to_html.py
+++ b/tests/test_json_to_html.py
@@ -43,14 +43,19 @@ def test_nested_elements():
             }
         ]
     }
-    expected = '<head><title>Floyd&#x27;s</title><meta charset="UTF-8"></head>'
+    expected = '<head><title>Floyd\'s</title><meta charset="UTF-8"></head>'
     assert html_to_json.json_to_html(json_input) == expected
 
 
 def test_special_characters_are_escaped():
     json_input = {'p': [{'_value': '<script>alert("x")</script>'}]}
-    expected = '<p>&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;</p>'
+    expected = '<p>&lt;script&gt;alert("x")&lt;/script&gt;</p>'
     assert html_to_json.json_to_html(json_input) == expected
+
+
+def test_quotes_in_text_are_not_escaped():
+    json_input = {'p': [{'_value': 'say "hi" & \'bye\''}]}
+    assert html_to_json.json_to_html(json_input) == '<p>say "hi" &amp; \'bye\'</p>'
 
 
 def test_attribute_values_are_escaped():

--- a/tests/test_json_to_html.py
+++ b/tests/test_json_to_html.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import html_to_json
+
+
+def test_empty_dict_returns_empty_string():
+    assert html_to_json.json_to_html({}) == ''
+
+
+def test_simple_value():
+    assert html_to_json.json_to_html({'p': [{'_value': 'hello'}]}) == '<p>hello</p>'
+
+
+def test_multiple_values():
+    assert html_to_json.json_to_html({'p': [{'_values': ['a', 'b']}]}) == '<p>ab</p>'
+
+
+def test_attributes():
+    json_input = {'a': [{'_attributes': {'href': 'https://example.com'}, '_value': 'link'}]}
+    assert html_to_json.json_to_html(json_input) == '<a href="https://example.com">link</a>'
+
+
+def test_void_element_no_closing_tag():
+    assert html_to_json.json_to_html({'br': [{}]}) == '<br>'
+
+
+def test_void_element_with_attributes():
+    json_input = {'meta': [{'_attributes': {'charset': 'UTF-8'}}]}
+    assert html_to_json.json_to_html(json_input) == '<meta charset="UTF-8">'
+
+
+def test_class_attribute_list_is_space_joined():
+    json_input = {'div': [{'_attributes': {'class': ['foo', 'bar']}, '_value': 'x'}]}
+    assert html_to_json.json_to_html(json_input) == '<div class="foo bar">x</div>'
+
+
+def test_nested_elements():
+    json_input = {
+        'head': [
+            {
+                'title': [{'_value': "Floyd's"}],
+                'meta': [{'_attributes': {'charset': 'UTF-8'}}],
+            }
+        ]
+    }
+    expected = '<head><title>Floyd&#x27;s</title><meta charset="UTF-8"></head>'
+    assert html_to_json.json_to_html(json_input) == expected
+
+
+def test_special_characters_are_escaped():
+    json_input = {'p': [{'_value': '<script>alert("x")</script>'}]}
+    expected = '<p>&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;</p>'
+    assert html_to_json.json_to_html(json_input) == expected
+
+
+def test_attribute_values_are_escaped():
+    json_input = {'a': [{'_attributes': {'title': 'He said "hi"'}, '_value': 'x'}]}
+    expected = '<a title="He said &quot;hi&quot;">x</a>'
+    assert html_to_json.json_to_html(json_input) == expected
+
+
+def test_repeated_tags_preserve_order():
+    json_input = {
+        'ul': [
+            {
+                'li': [
+                    {'_value': 'one'},
+                    {'_value': 'two'},
+                    {'_value': 'three'},
+                ]
+            }
+        ]
+    }
+    assert html_to_json.json_to_html(json_input) == '<ul><li>one</li><li>two</li><li>three</li></ul>'
+
+
+def test_roundtrip_simple():
+    html = "<head><title>Test</title><meta charset=\"UTF-8\"></head>"
+    json_output = html_to_json.convert(html)
+    assert html_to_json.json_to_html(json_output) == html
+
+
+def test_roundtrip_with_nested_anchors():
+    html = '<ul><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul>'
+    json_output = html_to_json.convert(html)
+    assert html_to_json.json_to_html(json_output) == html
+
+
+def test_roundtrip_lang_attribute_preserved():
+    html = '<html lang="en"><head><meta charset="utf-8"></head><body></body></html>'
+    json_output = html_to_json.convert(html)
+    assert html_to_json.json_to_html(json_output) == html
+
+
+def test_modify_then_convert_back():
+    """The core use case from issue #23: convert -> modify -> convert back."""
+    html = '<div><p>old text</p></div>'
+    json_output = html_to_json.convert(html)
+    json_output['div'][0]['p'][0]['_value'] = 'new text'
+    assert html_to_json.json_to_html(json_output) == '<div><p>new text</p></div>'
+
+
+def test_boolean_attribute_true_renders_bare():
+    json_input = {'input': [{'_attributes': {'type': 'checkbox', 'checked': True}}]}
+    assert html_to_json.json_to_html(json_input) == '<input type="checkbox" checked>'
+
+
+def test_boolean_attribute_false_omitted():
+    json_input = {'input': [{'_attributes': {'type': 'checkbox', 'checked': False}}]}
+    assert html_to_json.json_to_html(json_input) == '<input type="checkbox">'


### PR DESCRIPTION
## Changes

- Add `html_to_json.json_to_html()` to convert the JSON output of `convert()` back into an HTML string
- Handle HTML5 void elements (`<br>`, `<meta>`, `<img>`, etc.) by rendering them without a closing tag
- Space-join list-valued attributes (such as `class`/`rel`) back into a single attribute value
- Render boolean attributes bare when `True` and omit them when `False`
- HTML-escape text content and attribute values
- Add 17 tests covering values, attributes, void elements, escaping, list/boolean attributes, nested elements, and round-trips through `convert()` → `json_to_html()`
- Document the new function and its known round-trip limitations in the README
- Add a changelog entry under `[Unreleased]`