### PR TITLE
ci: cancel in-progress runs on new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Changes
- Add a top-level `concurrency` group (keyed on `${{ github.workflow }}-${{ github.ref }}`) with `cancel-in-progress: true` to the PR-triggered CI/lint workflows so superseded runs are cancelled when a new commit is pushed