### PR TITLE
convert_tables: don't crash on tables with no rows (#63 case 1)

### DIFF
--- a/html_to_json/convert_html_tables.py
+++ b/html_to_json/convert_html_tables.py
@@ -92,6 +92,13 @@ def _process_table(html_table: Tag, *, record_children: bool, record_html: bool,
     """Process the given table."""
     table_data: TableData = list()
 
+    if not html_table.find_all('tr'):
+        # A table with no rows (e.g. an empty ``<tbody>``, which many CMSes
+        # emit) has nothing to process. Return the empty result rather than
+        # indexing an empty ``find_all('tr')`` list below. ``convert_tables``
+        # drops empty results, so such tables are simply skipped.
+        return table_data
+
     table_class_debug_message = (
         'Processing table as a {} table '
         + '(you can read more about the different types of tables here: '

--- a/tests/test_html_tables_misc.py
+++ b/tests/test_html_tables_misc.py
@@ -13,6 +13,19 @@ def _read_file(file_name):
     return file_text
 
 
+def test_empty_table_is_skipped_without_crashing():
+    # A table with no rows (including the common empty <tbody> emitted by many
+    # CMSes) should produce no output rather than raising IndexError.
+    assert html_to_json.convert_tables('<table></table>') == []
+    assert html_to_json.convert_tables('<table><tbody></tbody></table>') == []
+
+
+def test_empty_table_alongside_a_real_table():
+    html_string = '<table></table><table><tr><td>1</td><td>2</td></tr></table>'
+    tables = html_to_json.convert_tables(html_string)
+    assert tables == [[['1', '2']]]
+
+
 def test_multiple_tables_in_single_document():
     html_string = _read_file('./data/test_two_tables.html')
     tables = html_to_json.convert_tables(html_string)


### PR DESCRIPTION
Picks off the unambiguous part of #63: an empty table crashes.

```python
import html_to_json
html_to_json.convert_tables('<table></table>')
html_to_json.convert_tables('<table><tbody></tbody></table>')
# IndexError: list index out of range
```

`_process_table` reads `find_all('tr')[0]` before checking that the table has any rows. An empty `<tbody>` is ordinary CMS output, so this isn't only an adversarial-input concern.

Added an early return of the empty result when there are no rows. `convert_tables` already drops empty results, so a rowless table is simply omitted (including when it sits next to a real table). Tables with rows are untouched.

I deliberately left the ragged/class-B cases from #63 out of this PR since, as you noted there, they need a semantics decision and case 2 overlaps with #64.

Added two tests in `test_html_tables_misc.py` (empty table alone, and empty table next to a real one). The empty-table case raises `IndexError` on `main` and passes with this change.